### PR TITLE
Refactor repository for dictionary learning capabilities.

### DIFF
--- a/data/neural_data_loader.py
+++ b/data/neural_data_loader.py
@@ -7,6 +7,8 @@ import torchvision.transforms as transforms # Already present in original script
 from pathlib import Path # Changed from pathlib to Path for direct use
 from torch.utils.data import Dataset # For the base class
 
+FILE_BASE_PATH = Path(__file__).resolve().parent
+
 # Custom Dataset to load from multiple session datasets produced by preprocess(i), with lazy evaluation and caching
 class MultiSessionConcatDataset(Dataset): # Changed base class to Dataset
     def __init__(self, session_ids, preprocess_fn, images=False): # PEP8: images=False
@@ -30,7 +32,7 @@ class MultiSessionConcatDataset(Dataset): # Changed base class to Dataset
         # Assuming this script is in 'refactored_code', and CSV is in 'neural_switch/data'
         # This relative path might need adjustment based on execution context.
         # For now, using the provided path, assuming it's accessible.
-        self.precomputed_lengths_path = Path('./../neural_switch/data/precomputed_lengths.csv') # More robust path
+        self.precomputed_lengths_path = FILE_BASE_PATH / '../neural_switch/data/precomputed_lengths.csv' # More robust path
         
         if self.precomputed_lengths_path.exists():
             self.precomputed_lengths_df = pd.read_csv(self.precomputed_lengths_path)
@@ -104,7 +106,7 @@ class MultiSessionConcatDataset(Dataset): # Changed base class to Dataset
         
         # Path to neural data, adjust if necessary
         # Assuming it's relative to where the main script using this class runs from.
-        neural_data_path = Path('./../neural_switch/data/neural_data') # More robust path
+        neural_data_path = FILE_BASE_PATH / '../neural_switch/data/neural_data' # More robust path
 
         try:
             features, img_paths = self.preprocess_fn(session_id, neural_data_path)
@@ -169,7 +171,7 @@ class MultiSessionConcatDataset(Dataset): # Changed base class to Dataset
             img_path_relative = img_paths_for_session[local_idx]
             # Base path for images, adjust if necessary
             # Assuming this path is relative to where the main script runs.
-            img_base_path = Path('./../data/manyOO/')
+            img_base_path = FILE_BASE_PATH / '../data/manyOO/'
             
             # Try primary path, then fallback to 'TestItems' subdirectory
             img_full_path = img_base_path / img_path_relative

--- a/main_dictionary_learning.py
+++ b/main_dictionary_learning.py
@@ -34,7 +34,7 @@ import pathlib # Already imported above
 # If data_handling.py is meant to be a module, it might need an __init__.py in the directory
 # and the import might be `from .data_handling import MultiSessionConcatDataset` if run as part of a package.
 # For now, using direct import as if it's in PYTHONPATH.
-from data_handling import MultiSessionConcatDataset
+from data.neural_data_loader import MultiSessionConcatDataset
 
 
 # Removed TCA import as it's not used in this part
@@ -47,15 +47,11 @@ print(f"Using device: {device}")
 # Ensure this path is correct relative to where original_script.py is executed from.
 # If original_script.py is in refactored_code, then './../data/Pa220227_0527.txt'
 # means it looks for 'data/Pa220227_0527.txt' in the parent of 'refactored_code'.
+# Now that the script is at the root, the path is direct.
 try:
-    lst_sess_file_path = './../data/Pa220227_0527.txt'
+    lst_sess_file_path = './data/Pa220227_0527.txt' # Adjusted for script at root
     if not os.path.exists(lst_sess_file_path):
-        # Try an alternative path if the script is run from the root of the repo
-        alt_lst_sess_file_path = './data/Pa220227_0527.txt'
-        if os.path.exists(alt_lst_sess_file_path):
-            lst_sess_file_path = alt_lst_sess_file_path
-        else:
-            raise FileNotFoundError(f"Session list file not found at {lst_sess_file_path} or {alt_lst_sess_file_path}")
+        raise FileNotFoundError(f"Session list file not found at {lst_sess_file_path}")
     lst_sess = [line.strip() for line in  open(lst_sess_file_path, 'r')]
 except FileNotFoundError as e:
     print(f"Error: {e}. Please ensure the session list file path is correct.")

--- a/test_models/data/many00_loader.py
+++ b/test_models/data/many00_loader.py
@@ -122,19 +122,28 @@ class Many00Dataset(Dataset):
         potential_classes.sort()
         
         if not potential_classes:
-            # If no subdirectories, treat all images in root as single class
-            self.classes = ['default']
-            self.class_to_idx = {'default': 0}
-            self._load_images_from_directory(self.root_path, 0)
-        else:
-            # Multiple classes based on subdirectories
-            self.classes = potential_classes
-            self.class_to_idx = {cls: idx for idx, cls in enumerate(self.classes)}
-            
-            for class_name in self.classes:
-                class_path = os.path.join(self.root_path, class_name)
-                class_idx = self.class_to_idx[class_name]
-                self._load_images_from_directory(class_path, class_idx)
+            raise FileNotFoundError(
+                f"No category subdirectories found in {self.root_path}. "
+                "Many00 dataset expects images to be organized into subfolders, "
+                "each representing a category."
+            )
+        
+        # Multiple classes based on subdirectories
+        self.classes = potential_classes
+        self.class_to_idx = {cls: idx for idx, cls in enumerate(self.classes)}
+        
+        for class_name in self.classes:
+            class_path = os.path.join(self.root_path, class_name)
+            class_idx = self.class_to_idx[class_name]
+            # Assuming images are directly in class_path, not further subdirectories within class_path
+            # So, recursive_search for _load_images_from_directory might be better set to False
+            # However, the current implementation of _load_images_from_directory handles both cases correctly.
+            # If recursive_search is True (default), it walks starting from class_path.
+            # If recursive_search is False, it lists files in class_path.
+            # For the structure 'root/category/image.jpg', either will work.
+            # Let's stick to the default recursive_search=True for flexibility,
+            # as it doesn't harm the specified structure.
+            self._load_images_from_directory(class_path, class_idx)
     
     def _load_images_from_directory(self, directory: str, class_idx: int):
         """Load all images from a directory."""

--- a/tests/test_main_dictionary_learning_components.py
+++ b/tests/test_main_dictionary_learning_components.py
@@ -1,0 +1,88 @@
+import unittest
+import torch
+import torch.nn as nn
+
+# To import DictionaryLearner, we need to ensure main_dictionary_learning.py
+# can be imported. This might require it to be structured to allow class import,
+# or temporarily add its path. For testing, it's common to adjust sys.path
+# or assume the test runner handles it.
+# Here, we'll try a direct import path assuming the structure allows it,
+# or that main_dictionary_learning.py defines the class at the top level.
+
+# If main_dictionary_learning.py is in root, and tests/ is a dir in root:
+# One way is to add project root to sys.path for the test.
+import sys
+import os
+# Assuming the test is run from the project root or tests/ directory
+# Add project root to path to find main_dictionary_learning
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from main_dictionary_learning import DictionaryLearner
+
+
+class TestDictionaryLearner(unittest.TestCase):
+
+    def test_initialization(self):
+        """Test the initialization of the DictionaryLearner model."""
+        input_dim = 64
+        n_components = 128
+        model = DictionaryLearner(input_dim, n_components)
+
+        self.assertIsInstance(model, nn.Module)
+        
+        # Check encoder structure
+        self.assertIsInstance(model.encoder, nn.Sequential)
+        self.assertEqual(len(model.encoder), 2) # Linear + ReLU
+        self.assertIsInstance(model.encoder[0], nn.Linear)
+        self.assertIsInstance(model.encoder[1], nn.ReLU)
+        
+        # Check encoder weight shapes
+        self.assertEqual(model.encoder[0].weight.shape, (n_components, input_dim))
+        self.assertEqual(model.encoder[0].bias.shape, (n_components,))
+        
+        # Check decoder structure
+        self.assertIsInstance(model.decoder, nn.Linear)
+        # Check decoder weight shapes
+        self.assertEqual(model.decoder.weight.shape, (input_dim, n_components))
+        self.assertEqual(model.decoder.bias.shape, (input_dim,))
+
+    def test_forward_pass(self):
+        """Test the forward pass of the DictionaryLearner model."""
+        input_dim = 64
+        n_components = 128
+        batch_size = 10
+        model = DictionaryLearner(input_dim, n_components)
+
+        # Create a dummy input tensor
+        dummy_input = torch.randn(batch_size, input_dim)
+
+        # Perform a forward pass
+        reconstructed_output = model(dummy_input)
+
+        # Check output shape
+        self.assertEqual(reconstructed_output.shape, (batch_size, input_dim))
+
+        # Check intermediate encoded shape and ReLU activation
+        encoded_output = model.encoder(dummy_input)
+        self.assertEqual(encoded_output.shape, (batch_size, n_components))
+        # Check if ReLU was applied (all values >= 0)
+        self.assertTrue(torch.all(encoded_output >= 0))
+        
+    def test_forward_pass_different_dims(self):
+        """Test with different dimensions to ensure robustness."""
+        input_dim = 256
+        n_components = 512
+        batch_size = 5
+        model = DictionaryLearner(input_dim, n_components)
+        dummy_input = torch.randn(batch_size, input_dim)
+        reconstructed_output = model(dummy_input)
+        self.assertEqual(reconstructed_output.shape, (batch_size, input_dim))
+        encoded_output = model.encoder(dummy_input)
+        self.assertEqual(encoded_output.shape, (batch_size, n_components))
+        self.assertTrue(torch.all(encoded_output >= 0))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_neural_data_loader.py
+++ b/tests/test_neural_data_loader.py
@@ -1,0 +1,217 @@
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import torch
+import numpy as np
+import pandas as pd
+from PIL import Image
+from pathlib import Path
+
+# Assuming 'data' is a top-level directory and the script is run from project root
+# or PYTHONPATH is set up.
+from data.neural_data_loader import MultiSessionConcatDataset
+
+# Define a global mock preprocess_fn for use in tests
+def mock_preprocess_fn(session_id, neural_data_path):
+    """
+    Mock preprocessing function.
+    neural_data_path is ignored in this mock.
+    """
+    if session_id == "sess1":
+        # (n_stimuli, 30 timepoints, 20 trials/units, 64 neurons)
+        return (np.random.rand(10, 30, 20, 64).astype(np.float32), 
+                [f"sess1_img_{i}.png" for i in range(10)])
+    elif session_id == "sess2":
+        return (np.random.rand(5, 30, 20, 64).astype(np.float32), 
+                [f"sess2_img_{i}.png" for i in range(5)])
+    elif session_id == "empty_sess": # Session returns 0 samples
+        return (np.zeros((0, 30, 20, 64)).astype(np.float32), [])
+    elif session_id == "bad_features_sess": # Features with wrong final dimension
+        return (np.random.rand(5, 30, 20, 32).astype(np.float32), 
+                [f"bad_sess_img_{i}.png" for i in range(5)])
+    elif session_id == "error_sess": # Simulates an error during preprocessing
+        raise ValueError("Simulated preprocessing error")
+    elif session_id == "none_features_sess": # Simulates preprocess_fn returning None for features
+        return (None, [f"none_feat_img_{i}.png" for i in range(5)])
+    else:
+        # Default for any other session_id, effectively an empty/invalid session
+        return (None, None)
+
+
+class TestMultiSessionConcatDataset(unittest.TestCase):
+
+    def setUp(self):
+        self.session_ids_valid = ["sess1", "sess2"]
+        self.mock_preprocess_fn_global = mock_preprocess_fn
+
+        # Mock image for Image.open
+        self.mock_pil_image = Image.new('RGB', (256, 256), color='blue')
+
+    @patch('data.neural_data_loader.pd.DataFrame.to_csv')
+    @patch('data.neural_data_loader.pd.read_csv')
+    @patch('data.neural_data_loader.Path.exists')
+    def test_basic_concatenation_and_lengths(self, mock_path_exists, mock_read_csv, mock_to_csv):
+        """Test basic dataset concatenation, length, and cumulative lengths."""
+        mock_path_exists.return_value = False # No precomputed_lengths.csv
+
+        dataset = MultiSessionConcatDataset(
+            session_ids=self.session_ids_valid,
+            preprocess_fn=self.mock_preprocess_fn_global
+        )
+
+        self.assertEqual(len(dataset), 15) # 10 from sess1 + 5 from sess2
+        self.assertEqual(dataset.total_length, 15)
+        self.assertEqual(dataset.session_ids, ["sess1", "sess2"]) # Order maintained
+        self.assertEqual(dataset.lengths, [10, 5])
+        self.assertEqual(dataset.cum_lengths, [0, 10, 15])
+        # Check that to_csv was called for sess1 and sess2 as lengths were computed
+        self.assertEqual(mock_to_csv.call_count, 2)
+
+
+    @patch('data.neural_data_loader.Image.open')
+    @patch('data.neural_data_loader.Path.is_file')
+    @patch('data.neural_data_loader.pd.DataFrame.to_csv')
+    @patch('data.neural_data_loader.pd.read_csv')
+    @patch('data.neural_data_loader.Path.exists')
+    def test_getitem_no_images(self, mock_path_exists, mock_read_csv, mock_to_csv, mock_is_file, mock_image_open):
+        """Test __getitem__ when images=False."""
+        mock_path_exists.return_value = False
+        mock_is_file.return_value = True # Assume all image paths are valid files
+        mock_image_open.return_value = self.mock_pil_image
+
+        dataset = MultiSessionConcatDataset(
+            session_ids=self.session_ids_valid,
+            preprocess_fn=self.mock_preprocess_fn_global,
+            images=False # Default
+        )
+        
+        # Item from sess1
+        features_sess1 = dataset[0] 
+        self.assertIsInstance(features_sess1, torch.Tensor)
+         # Expected shape: (30 timepoints, 64 neurons) after .mean(axis=2) in _load_and_process_session
+        self.assertEqual(features_sess1.shape, (30, 64))
+
+        # Item from sess2 (index 10 is the first item of sess2)
+        features_sess2 = dataset[10]
+        self.assertIsInstance(features_sess2, torch.Tensor)
+        self.assertEqual(features_sess2.shape, (30, 64))
+        
+        # Check that Image.open was not called
+        mock_image_open.assert_not_called()
+
+    @patch('data.neural_data_loader.Image.open')
+    @patch('data.neural_data_loader.Path.is_file')
+    @patch('data.neural_data_loader.pd.DataFrame.to_csv')
+    @patch('data.neural_data_loader.pd.read_csv')
+    @patch('data.neural_data_loader.Path.exists')
+    def test_getitem_with_images(self, mock_path_exists, mock_read_csv, mock_to_csv, mock_is_file, mock_image_open):
+        """Test __getitem__ when images=True."""
+        mock_path_exists.return_value = False
+        mock_is_file.return_value = True # Assume all image paths are valid
+        mock_image_open.return_value = self.mock_pil_image
+
+        dataset = MultiSessionConcatDataset(
+            session_ids=self.session_ids_valid,
+            preprocess_fn=self.mock_preprocess_fn_global,
+            images=True
+        )
+
+        features, img_tensor = dataset[0] # First item from sess1
+        self.assertIsInstance(features, torch.Tensor)
+        self.assertEqual(features.shape, (30, 64))
+        self.assertIsInstance(img_tensor, torch.Tensor)
+        # Default transform in __getitem__ for images: Resize(256,256), ToTensor, Lambda for 3 channels
+        self.assertEqual(img_tensor.shape, (3, 256, 256)) 
+        mock_image_open.assert_called_once() # Should be called once for this item
+        
+        # Check path construction for image (assuming FILE_BASE_PATH / '../data/manyOO/' / img_path_relative)
+        # The actual img_path_relative is "sess1_img_0.png"
+        # FILE_BASE_PATH for data/neural_data_loader.py is data/
+        # So, data/../data/manyOO/sess1_img_0.png = data/manyOO/sess1_img_0.png
+        expected_img_path = Path('data/manyOO/sess1_img_0.png')
+        
+        # mock_image_open.assert_called_with(expected_img_path) # This is tricky due to Path object comparison
+        args, _ = mock_image_open.call_args
+        called_path = args[0]
+        self.assertIsInstance(called_path, Path)
+        # Check parts of the path if direct comparison is problematic
+        self.assertTrue(str(called_path).endswith('data/manyOO/sess1_img_0.png'))
+
+
+    @patch('data.neural_data_loader.pd.DataFrame.to_csv')
+    @patch('data.neural_data_loader.pd.read_csv')
+    @patch('data.neural_data_loader.Path.exists')
+    def test_session_skipping_and_error_handling(self, mock_path_exists, mock_read_csv, mock_to_csv):
+        """Test that invalid sessions are skipped and errors handled."""
+        mock_path_exists.return_value = False
+        session_ids = ["sess1", "empty_sess", "bad_features_sess", "error_sess", "none_features_sess", "sess2"]
+        
+        dataset = MultiSessionConcatDataset(
+            session_ids=session_ids,
+            preprocess_fn=self.mock_preprocess_fn_global
+        )
+
+        self.assertEqual(len(dataset), 15) # Only sess1 (10) and sess2 (5) should be included
+        self.assertEqual(dataset.session_ids, ["sess1", "sess2"])
+        self.assertEqual(dataset.lengths, [10, 5])
+        self.assertEqual(dataset.cum_lengths, [0, 10, 15])
+
+    @patch('data.neural_data_loader.pd.DataFrame.to_csv')
+    @patch('data.neural_data_loader.pd.read_csv')
+    @patch('data.neural_data_loader.Path.exists')
+    def test_precomputed_lengths_integration(self, mock_path_exists, mock_read_csv, mock_to_csv):
+        """Test interaction with precomputed_lengths.csv."""
+        # Scenario 1: precomputed_lengths.csv does not exist
+        mock_path_exists.return_value = False
+        dataset1 = MultiSessionConcatDataset(["sess1"], self.mock_preprocess_fn_global)
+        self.assertEqual(len(dataset1), 10)
+        mock_to_csv.assert_called_once() # Called to save newly computed length for sess1
+        # The path used by to_csv should be dataset1.precomputed_lengths_path
+        args_to_csv, _ = mock_to_csv.call_args
+        self.assertEqual(args_to_csv[0], dataset1.precomputed_lengths_path)
+
+
+        mock_to_csv.reset_mock()
+
+        # Scenario 2: precomputed_lengths.csv exists and lengths are correct
+        mock_path_exists.return_value = True
+        mock_df = pd.DataFrame([{'session_id': 'sess1', 'length': 10}])
+        mock_read_csv.return_value = mock_df
+        
+        dataset2 = MultiSessionConcatDataset(["sess1"], self.mock_preprocess_fn_global)
+        self.assertEqual(len(dataset2), 10)
+        mock_read_csv.assert_called_once_with(dataset2.precomputed_lengths_path)
+        mock_to_csv.assert_not_called() # Not called because length matched
+
+        mock_read_csv.reset_mock()
+        mock_to_csv.reset_mock()
+
+        # Scenario 3: precomputed_lengths.csv exists, but length for a session is incorrect
+        mock_df_incorrect = pd.DataFrame([{'session_id': 'sess1', 'length': 8}, {'session_id': 'sess2', 'length': 5}])
+        mock_read_csv.return_value = mock_df_incorrect
+        
+        dataset3 = MultiSessionConcatDataset(["sess1", "sess2"], self.mock_preprocess_fn_global)
+        self.assertEqual(len(dataset3), 15) # sess1 is 10, sess2 is 5
+        self.assertEqual(dataset3.lengths, [10, 5]) # Correct lengths are used
+        # to_csv should be called to update the incorrect length of sess1
+        # (and possibly for sess2 if its entry was missing, but here it's correct)
+        
+        # Check the updated DataFrame that would be saved
+        # The df in dataset3.precomputed_lengths_df should be updated
+        updated_df_sess1_length = dataset3.precomputed_lengths_df[
+            dataset3.precomputed_lengths_df['session_id'] == 'sess1'
+        ]['length'].iloc[0]
+        self.assertEqual(updated_df_sess1_length, 10)
+        
+        mock_to_csv.assert_called() # Called at least for sess1
+        
+        # Check if it was called for 'sess1' because its length changed
+        # This is a bit more involved to check precisely which rows triggered save without more complex mocking
+        # But we know it must have been called due to the mismatch for sess1.
+        # A simple check is that it's called. If it was called once, it implies sess1 was updated.
+        # If sess2 was also missing from a hypothetical csv and then added, call_count would be 2.
+        # Here, sess1 (8->10) triggers save. sess2 (5->5) does not. So 1 call.
+        self.assertEqual(mock_to_csv.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses the issue of cleaning the repository and focusing its capabilities on dictionary learning from neural data and ResNet50 features.

Key changes include:

1.  **Implemented `Many00DataLoader`:** Updated `test_models/data/many00_loader.py` to correctly load images from a directory structure with category subfolders.
2.  **Consolidated Neural Data Loading:** Moved `refactored_code/data_handling.py` to `data/neural_data_loader.py` (as `MultiSessionConcatDataset`) and updated its usage and internal path handling.
3.  **Refactored Main Dictionary Learning Script:** Moved `refactored_code/original_script.py` to `main_dictionary_learning.py` in the root. This script now serves as the primary interface for dictionary learning on neural data and on features from a model replicating neural data (ResNet50 + linear regression).
4.  **Updated `test_models/` Functionality:** Ensured `test_models/main.py` correctly performs dictionary learning on ResNet50 features (ImageNet) and integrated the `Many00DataLoader` as a selectable dataset option.
5.  **Cleaned Up Unused Files:** Removed the old sparse autoencoder implementation (`./models/sparse_autoencoder.py`, `./train.py`, `./inference.py`) and associated utilities in `./utils/` as they were confirmed to be obsolete or already non-existent. The `refactored_code/` directory was also removed as its contents were integrated elsewhere.
6.  **Added and Updated Unit Tests:**
    *   Added tests for `Many00DataLoader` (`test_models/tests/test_data_loaders.py`).
    *   Added tests for `MultiSessionConcatDataset` (`tests/test_neural_data_loader.py`).
    *   Added tests for the `DictionaryLearner` model component from `main_dictionary_learning.py` (`tests/test_main_dictionary_learning_components.py`).
    *   Reviewed and confirmed the relevance of existing tests in `test_models/tests/`.

The repository structure is now cleaner, and the core functionalities are better defined and tested.